### PR TITLE
Correct173

### DIFF
--- a/src/Progracqteur/WikipedaleBundle/Controller/PlaceController.php
+++ b/src/Progracqteur/WikipedaleBundle/Controller/PlaceController.php
@@ -344,6 +344,8 @@ class PlaceController extends Controller {
             
         }
         
+        $place->checkEmptyPlaceTracking();
+        
         $em = $this->getDoctrine()->getEntityManager();
         $em->persist($place);
         $em->flush();

--- a/src/Progracqteur/WikipedaleBundle/Controller/PlaceController.php
+++ b/src/Progracqteur/WikipedaleBundle/Controller/PlaceController.php
@@ -344,7 +344,6 @@ class PlaceController extends Controller {
             
         }
         
-        $place->checkEmptyPlaceTracking();
         
         $em = $this->getDoctrine()->getEntityManager();
         $em->persist($place);

--- a/src/Progracqteur/WikipedaleBundle/Entity/Model/Place.php
+++ b/src/Progracqteur/WikipedaleBundle/Entity/Model/Place.php
@@ -990,6 +990,23 @@ class Place implements ChangeableInterface, NotifyPropertyChanged
         
         return $this->changeset;
     }
+    
+    private function destroyCurrentChangeset() {
+        $changeset = $this->getChangeset();
+        
+        $hashId = spl_object_hash($changeset);
+        
+        foreach ($this->changesets as $key => $value) {
+            if ($hashId === spl_object_hash($value)) {
+                $this->changesets->remove($key);
+            }
+        }
+        
+        $this->changeset = null;
+        
+        unset($changeset);
+        
+    }
 
     public function addPropertyChangedListener(PropertyChangedListener $listener) {
         $this->_listeners[] = $listener;
@@ -1104,6 +1121,17 @@ class Place implements ChangeableInterface, NotifyPropertyChanged
         {
             $context->addViolationAtSubPath('manager', 'validation.place.manager.group_is_not_type_manager', 
                     array(), $this->getManager());
+        }
+    }
+    
+    public function checkEmptyPlaceTracking() {
+        $placeTracking = $this->getChangeset();
+        
+        $changes = $placeTracking->getChanges();
+        
+        
+        if (count($changes) === 0) {
+            $this->destroyCurrentChangeset();
         }
     }
 }

--- a/src/Progracqteur/WikipedaleBundle/Entity/Model/Place.php
+++ b/src/Progracqteur/WikipedaleBundle/Entity/Model/Place.php
@@ -985,7 +985,7 @@ class Place implements ChangeableInterface, NotifyPropertyChanged
         if ($this->changeset === null)
         {
             $this->changeset = new Place\PlaceTracking($this);
-            $this->changesets->add($this->changeset);
+            //$this->changesets->add($this->changeset);
         }
         
         return $this->changeset;
@@ -1132,6 +1132,17 @@ class Place implements ChangeableInterface, NotifyPropertyChanged
         
         if (count($changes) === 0) {
             $this->destroyCurrentChangeset();
+        }
+    }
+    
+    public function registerCurrentChangeset() {
+        $placeTracking = $this->getChangeset();
+        
+        $changes = $placeTracking->getChanges();
+        
+        
+        if (count($changes) > 0) {
+            $this->changesets->add($placeTracking);
         }
     }
 }

--- a/src/Progracqteur/WikipedaleBundle/Entity/Model/Place/PlaceTracking.php
+++ b/src/Progracqteur/WikipedaleBundle/Entity/Model/Place/PlaceTracking.php
@@ -308,6 +308,10 @@ class PlaceTracking implements ChangesetInterface {
             //}
         }
     }
+    
+    public function checkIfEmpty() {
+        $this->getPlace()->checkEmptyPlaceTracking();
+    }
 
 }
 

--- a/src/Progracqteur/WikipedaleBundle/Resources/config/doctrine/Model.Place.PlaceTracking.orm.yml
+++ b/src/Progracqteur/WikipedaleBundle/Resources/config/doctrine/Model.Place.PlaceTracking.orm.yml
@@ -17,9 +17,6 @@ Progracqteur\WikipedaleBundle\Entity\Model\Place\PlaceTracking:
       type: hash
     date:
       type: datetime
-  lifecycleCallbacks:
-    #checkIfEmpty seems to be not efficient
-    prePersist: [checkIfEmpty]
   manyToOne:
     author:
       targetEntity: Progracqteur\WikipedaleBundle\Entity\Management\User

--- a/src/Progracqteur/WikipedaleBundle/Resources/config/doctrine/Model.Place.PlaceTracking.orm.yml
+++ b/src/Progracqteur/WikipedaleBundle/Resources/config/doctrine/Model.Place.PlaceTracking.orm.yml
@@ -17,6 +17,9 @@ Progracqteur\WikipedaleBundle\Entity\Model\Place\PlaceTracking:
       type: hash
     date:
       type: datetime
+  lifecycleCallbacks:
+    #checkIfEmpty seems to be not efficient
+    prePersist: [checkIfEmpty]
   manyToOne:
     author:
       targetEntity: Progracqteur\WikipedaleBundle\Entity\Management\User

--- a/src/Progracqteur/WikipedaleBundle/Resources/config/doctrine/Model.Place.orm.yml
+++ b/src/Progracqteur/WikipedaleBundle/Resources/config/doctrine/Model.Place.orm.yml
@@ -33,6 +33,9 @@ Progracqteur\WikipedaleBundle\Entity\Model\Place:
       default: true
     moderatorComment:
       type: text
+  lifecycleCallbacks:
+#    prePersist: [registerCurrentChangeset]
+    preFlush: [registerCurrentChangeset]
   manyToOne:
 #    category:
 #      targetEntity: Progracqteur\WikipedaleBundle\Entity\Model\Category


### PR DESCRIPTION
ajout d'un lifeCycleCallback sur entity place.

Le placeTracking n'est associé à la place modifié qu'au moment de preFlush. une vérification est faite que des éléments ont effectivement été ajouté à la placeTracking AVANT l'enregistrement de celle-ci.
